### PR TITLE
Adjust SQL query for mariadb compatibility

### DIFF
--- a/bin/user/airlink.py
+++ b/bin/user/airlink.py
@@ -660,7 +660,7 @@ class AQI(weewx.xtypes.XType):
                                            aggregate_interval)
         else:
             # No aggregation.
-            sql_str = 'SELECT dateTime, usUnits, interval, pm2_5 FROM %s ' \
+            sql_str = 'SELECT dateTime, usUnits, `interval`, pm2_5 FROM %s ' \
                       'WHERE dateTime >= ? AND dateTime <= ? AND pm2_5 IS NOT NULL' \
                       % db_manager.table_name
             std_unit_system = None


### PR DESCRIPTION
## What Changed?

A SQL query for the `pm2_5` value.

## Why is it Needed?

To run with a MariaDB/MySQL backend, this change is needed because `interval` is a reserved keyword.
