### PR TITLE
Too much loop packet debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ If you don't meet the following requirements, do not install this extension.
 
    ```
    [AirLink]
+       # extra_verbose = true
        [[Sensor1]]
            enable = true
            hostname = airlink

--- a/bin/user/airlink.py
+++ b/bin/user/airlink.py
@@ -252,7 +252,7 @@ def collect_data(hostname, port, timeout, archive_interval):
                 error = j['error']
                 code = error['code']
                 message = error['message']
-                log.info('%s returned error(%d): %s' % (url, code, message))
+                log.error('%s returned error(%d): %s' % (url, code, message))
                 return None
             # If data structure type 5, convert it to 6.
             if j['data']['conditions'][0]['data_structure_type'] == 5:
@@ -260,7 +260,7 @@ def collect_data(hostname, port, timeout, archive_interval):
             # Check for sanity
             sane, msg = is_sane(j)
             if not sane:
-                log.info('Reading not sane:  %s (%s)' % (msg, j))
+                log.error('Reading not sane:  %s (%s)' % (msg, j))
                 return None
             time_of_reading = j['data']['conditions'][0]['last_report_time']
             # The reading could be old.
@@ -272,7 +272,7 @@ def collect_data(hostname, port, timeout, archive_interval):
                 # time.  Check for this by checking if concentrations.pm_1
                 # is None.
                 if j['data']['conditions'][0]['pm_1'] is None:
-                    log.info('last_report_time must be time since boot: %d seconds.  Record: %s'
+                    log.error('last_report_time must be time since boot: %d seconds.  Record: %s'
                              % (time_of_reading, j))
                 else:
                     # Not current.  (Note: Rarely, spurious timestamps (e.g., 2016 in 2020)
@@ -289,11 +289,11 @@ def collect_data(hostname, port, timeout, archive_interval):
                     # 'last_report_time': 1461926886, 'pct_pm_data_last_1_hour': 100,
                     # 'pct_pm_data_last_3_hours': 100, 'pct_pm_data_nowcast': 100,
                     # 'pct_pm_data_last_24_hours': 100}]}, 'error': None}
-                    log.info('Ignoring reading from %s--age: %d seconds.  Record: %s'
+                    log.error('Ignoring reading from %s--age: %d seconds.  Record: %s'
                              % (hostname, age_of_reading, j))
                 j = None
     except Exception as e:
-        log.info('collect_data: Attempt to fetch from: %s failed: %s.' % (hostname, e))
+        log.error('collect_data: Attempt to fetch from: %s failed: %s.' % (hostname, e))
         j = None
 
 

--- a/bin/user/airlink.py
+++ b/bin/user/airlink.py
@@ -641,9 +641,10 @@ class AQI(weewx.xtypes.XType):
         if obs_type not in [ 'pm2_5_aqi', 'pm2_5_aqi_color' ]:
             raise weewx.UnknownType(obs_type)
 
-        log.debug('get_series(%s, %s, %s, aggregate:%s, aggregate_interval:%s)' % (
-            obs_type, timestamp_to_string(timespan.start), timestamp_to_string(
-            timespan.stop), aggregate_type, aggregate_interval))
+        if extra_verbose:
+            log.debug('get_series(%s, %s, %s, aggregate:%s, aggregate_interval:%s)' % (
+                obs_type, timestamp_to_string(timespan.start), timestamp_to_string(
+                timespan.stop), aggregate_type, aggregate_interval))
 
         #  Prepare the lists that will hold the final results.
         start_vec = list()
@@ -675,9 +676,10 @@ class AQI(weewx.xtypes.XType):
                     value = AQI.compute_pm2_5_aqi(pm2_5)
                 if obs_type == 'pm2_5_aqi_color':
                     value = AQI.compute_pm2_5_aqi_color(AQI.compute_pm2_5_aqi(pm2_5))
-                log.debug('get_series(%s): %s - %s - %s' % (obs_type,
-                    timestamp_to_string(ts - interval * 60),
-                    timestamp_to_string(ts), value))
+                if extra_verbose:
+                    log.debug('get_series(%s): %s - %s - %s' % (obs_type,
+                        timestamp_to_string(ts - interval * 60),
+                        timestamp_to_string(ts), value))
                 start_vec.append(ts - interval * 60)
                 stop_vec.append(ts)
                 data_vec.append(value)

--- a/install.py
+++ b/install.py
@@ -47,6 +47,7 @@ class AirLinkInstaller(ExtensionInstaller):
                     },
                 },
                 'AirLink': {
+                    '#extra_verbose' : True,
                     'Sensor1'  : {
                         'enable'     : True,
                         'hostname'   : 'airlink',

--- a/install.py
+++ b/install.py
@@ -47,7 +47,7 @@ class AirLinkInstaller(ExtensionInstaller):
                     },
                 },
                 'AirLink': {
-                    '#extra_verbose' : True,
+                    'extra_verbose' : True,
                     'Sensor1'  : {
                         'enable'     : True,
                         'hostname'   : 'airlink',


### PR DESCRIPTION
Just got a Davis AirLink 7210 and your driver works very well, so thank you for that.

However the driver logs a lot of debug information that's only needed for debugging, especially since this happens for every loop packet.

This PR adds an option to weewx.conf to limit it, disabled by default.

I would have added an info log entry when an archive update happens, but I couldn't work out where such a line would go.

I also changed a few log.info() lines to be log.error() since they are really errors and should stand out in logs.